### PR TITLE
Right-size options menu

### DIFF
--- a/Z1R_Tracker/Z1R_Avalonia/OptionsMenu.fs
+++ b/Z1R_Tracker/Z1R_Avalonia/OptionsMenu.fs
@@ -16,30 +16,28 @@ let data1 = [|
     "Show magnifier", "Display magnified view of overworld tiles when mousing", TrackerModel.Options.Overworld.ShowMagnifier
     |]
 
-let makeOptionsCanvas(width, height, heightOffset) = 
-    let optionsCanvas = new Canvas(Width=width, Height=height, Opacity=0., IsHitTestVisible=false)
-
+let makeOptionsCanvas(heightOffset) = 
     let options1sp = new StackPanel(Orientation=Orientation.Vertical, Margin=Thickness(10.,0.,10.,0.))
-    let tb = new TextBox(Text="Overworld settings", IsReadOnly=true, Margin=Thickness(0.,heightOffset,0.,0.), FontWeight=FontWeight.Bold)
+    let tb = new TextBox(Text="Overworld settings", IsReadOnly=true, Margin=Thickness(0.,heightOffset,0.,0.), FontWeight=FontWeight.Bold, BorderBrush=Brushes.Transparent)
     options1sp.Children.Add(tb) |> ignore
     for text,tip,b in data1 do
-        let cb = new CheckBox(Content=new TextBox(Text=text,IsReadOnly=true))
+        let cb = new CheckBox(Content=new TextBox(Text=text,IsReadOnly=true, BorderBrush=Brushes.Transparent))
         ToolTip.SetTip(cb,tip)
         link(cb, b)
         options1sp.Children.Add(cb) |> ignore
-    let optionsAllsp = new StackPanel(Orientation=Orientation.Horizontal)
+    let optionsAllsp = new StackPanel(Orientation=Orientation.Horizontal, Margin=Thickness(2.))
     optionsAllsp.Children.Add(options1sp) |> ignore
 
-    let options3sp = new StackPanel(Orientation=Orientation.Vertical, Margin=Thickness(10.,2.,0.,0.))
-    let tb = new TextBox(Text="Other", IsReadOnly=true, FontWeight=FontWeight.Bold)
+    let options3sp = new StackPanel(Orientation=Orientation.Vertical, Margin=Thickness(10.,0.,0.,0.))
+    let tb = new TextBox(Text="Other", IsReadOnly=true, FontWeight=FontWeight.Bold, BorderBrush=Brushes.Transparent)
     options3sp.Children.Add(tb) |> ignore
-    let cb = new CheckBox(Content=new TextBox(Text="Second quest dungeons",IsReadOnly=true))
+    let cb = new CheckBox(Content=new TextBox(Text="Second quest dungeons",IsReadOnly=true, BorderBrush=Brushes.Transparent))
     cb.IsChecked <- System.Nullable.op_Implicit TrackerModel.Options.IsSecondQuestDungeons.Value
     cb.Checked.Add(fun _ -> TrackerModel.Options.IsSecondQuestDungeons.Value <- true; TrackerModel.forceUpdate())
     cb.Unchecked.Add(fun _ -> TrackerModel.Options.IsSecondQuestDungeons.Value <- false; TrackerModel.forceUpdate())
     ToolTip.SetTip(cb,"Check this if dungeon 4, rather than dungeon 1, has 3 items")
     options3sp.Children.Add(cb) |> ignore
-    let cb = new CheckBox(Content=new TextBox(Text="Mirror overworld",IsReadOnly=true))
+    let cb = new CheckBox(Content=new TextBox(Text="Mirror overworld",IsReadOnly=true, BorderBrush=Brushes.Transparent))
     cb.IsChecked <- System.Nullable.op_Implicit TrackerModel.Options.MirrorOverworld.Value
     cb.Checked.Add(fun _ -> TrackerModel.Options.MirrorOverworld.Value <- true; TrackerModel.forceUpdate())
     cb.Unchecked.Add(fun _ -> TrackerModel.Options.MirrorOverworld.Value <- false; TrackerModel.forceUpdate())
@@ -48,5 +46,4 @@ let makeOptionsCanvas(width, height, heightOffset) =
 
     optionsAllsp.Children.Add(options3sp) |> ignore
 
-    Graphics.canvasAdd(optionsCanvas, optionsAllsp, 0., 0.)
-    optionsCanvas
+    optionsAllsp

--- a/Z1R_Tracker/Z1R_Avalonia/OptionsMenu.fs
+++ b/Z1R_Tracker/Z1R_Avalonia/OptionsMenu.fs
@@ -18,10 +18,10 @@ let data1 = [|
 
 let makeOptionsCanvas(heightOffset) = 
     let options1sp = new StackPanel(Orientation=Orientation.Vertical, Margin=Thickness(10.,0.,10.,0.))
-    let tb = new TextBox(Text="Overworld settings", IsReadOnly=true, Margin=Thickness(0.,heightOffset,0.,0.), FontWeight=FontWeight.Bold, BorderBrush=Brushes.Transparent)
+    let tb = new TextBox(Text="Overworld settings", IsReadOnly=true, Margin=Thickness(0.,heightOffset,0.,0.), FontWeight=FontWeight.Bold, BorderBrush=Brushes.Transparent, IsHitTestVisible=false)
     options1sp.Children.Add(tb) |> ignore
     for text,tip,b in data1 do
-        let cb = new CheckBox(Content=new TextBox(Text=text,IsReadOnly=true, BorderBrush=Brushes.Transparent))
+        let cb = new CheckBox(Content=new TextBox(Text=text,IsReadOnly=true, BorderBrush=Brushes.Transparent, IsHitTestVisible=false))
         ToolTip.SetTip(cb,tip)
         link(cb, b)
         options1sp.Children.Add(cb) |> ignore
@@ -29,15 +29,15 @@ let makeOptionsCanvas(heightOffset) =
     optionsAllsp.Children.Add(options1sp) |> ignore
 
     let options3sp = new StackPanel(Orientation=Orientation.Vertical, Margin=Thickness(10.,0.,0.,0.))
-    let tb = new TextBox(Text="Other", IsReadOnly=true, FontWeight=FontWeight.Bold, BorderBrush=Brushes.Transparent)
+    let tb = new TextBox(Text="Other", IsReadOnly=true, FontWeight=FontWeight.Bold, BorderBrush=Brushes.Transparent, IsHitTestVisible=false)
     options3sp.Children.Add(tb) |> ignore
-    let cb = new CheckBox(Content=new TextBox(Text="Second quest dungeons",IsReadOnly=true, BorderBrush=Brushes.Transparent))
+    let cb = new CheckBox(Content=new TextBox(Text="Second quest dungeons",IsReadOnly=true, BorderBrush=Brushes.Transparent, IsHitTestVisible=false))
     cb.IsChecked <- System.Nullable.op_Implicit TrackerModel.Options.IsSecondQuestDungeons.Value
     cb.Checked.Add(fun _ -> TrackerModel.Options.IsSecondQuestDungeons.Value <- true; TrackerModel.forceUpdate())
     cb.Unchecked.Add(fun _ -> TrackerModel.Options.IsSecondQuestDungeons.Value <- false; TrackerModel.forceUpdate())
     ToolTip.SetTip(cb,"Check this if dungeon 4, rather than dungeon 1, has 3 items")
     options3sp.Children.Add(cb) |> ignore
-    let cb = new CheckBox(Content=new TextBox(Text="Mirror overworld",IsReadOnly=true, BorderBrush=Brushes.Transparent))
+    let cb = new CheckBox(Content=new TextBox(Text="Mirror overworld",IsReadOnly=true, BorderBrush=Brushes.Transparent, IsHitTestVisible=false))
     cb.IsChecked <- System.Nullable.op_Implicit TrackerModel.Options.MirrorOverworld.Value
     cb.Checked.Add(fun _ -> TrackerModel.Options.MirrorOverworld.Value <- true; TrackerModel.forceUpdate())
     cb.Unchecked.Add(fun _ -> TrackerModel.Options.MirrorOverworld.Value <- false; TrackerModel.forceUpdate())

--- a/Z1R_Tracker/Z1R_Avalonia/Program.fs
+++ b/Z1R_Tracker/Z1R_Avalonia/Program.fs
@@ -59,9 +59,7 @@ type MyWindow(owMapNum) as this =
         let tb = dock <| new TextBox(Text="Settings (most can be changed later, using 'Options...' button above timeline):", Margin=spacing)
         stackPanel.Children.Add(tb) |> ignore
         TrackerModel.Options.readSettings()
-        let options = OptionsMenu.makeOptionsCanvas(16.*OverworldRouteDrawing.OMTW, float(UI.TCH+6), 0.)
-        options.IsHitTestVisible <- true
-        options.Opacity <- 1.0
+        let options = OptionsMenu.makeOptionsCanvas(0.)
         stackPanel.Children.Add(options) |> ignore
 
         let tb = dock <| new TextBox(Text="\nNote: once you start, you can use F5 to\nplace the 'start spot' icon at your mouse,\nor F10 to reset the timer to 0, at any time\n",IsReadOnly=true, Margin=spacing, MaxWidth=300.)

--- a/Z1R_Tracker/Z1R_Avalonia/UI.fs
+++ b/Z1R_Tracker/Z1R_Avalonia/UI.fs
@@ -35,9 +35,9 @@ let makeGrid = Graphics.makeGrid
 let triforceInnerCanvases = Array.zeroCreate 8
 let mainTrackerCanvases : Canvas[,] = Array2D.zeroCreate 9 4
 let mainTrackerCanvasShaders : Canvas[,] = Array2D.init 8 4 (fun _ _ -> new Canvas(Width=30., Height=30., Background=Brushes.Black, Opacity=0.4, IsHitTestVisible=false))
-let currentHeartsTextBox = new TextBox(Width=200., FontSize=14., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text=sprintf "Current Hearts: %d" TrackerModel.playerComputedStateSummary.PlayerHearts)
-let owRemainingScreensTextBox = new TextBox(Width=150., FontSize=14., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text=sprintf "%d OW spots left" TrackerModel.mapStateSummary.OwSpotsRemain)
-let owGettableScreensTextBox = new TextBox(Width=150., FontSize=14., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text=sprintf "Show %d gettable" TrackerModel.mapStateSummary.OwGettableLocations.Count)
+let currentHeartsTextBox = new TextBox(Width=200., FontSize=14., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text=sprintf "Current Hearts: %d" TrackerModel.playerComputedStateSummary.PlayerHearts, Padding=Thickness(0.))
+let owRemainingScreensTextBox = new TextBox(Width=150., FontSize=14., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text=sprintf "%d OW spots left" TrackerModel.mapStateSummary.OwSpotsRemain, Padding=Thickness(0.))
+let owGettableScreensTextBox = new TextBox(Width=150., FontSize=14., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text=sprintf "Show %d gettable" TrackerModel.mapStateSummary.OwGettableLocations.Count, Padding=Thickness(0.))
 let owGettableScreensCheckBox = new CheckBox(Content = owGettableScreensTextBox)
 
 let drawRoutesTo(routeDrawingCanvas, point, i, j, drawRouteMarks, maxYellowGreenHighlights) =
@@ -232,9 +232,9 @@ let makeAll(owMapNum) =
     let mutable hideFirstQuestFromMixed = fun b -> ()
     let mutable hideSecondQuestFromMixed = fun b -> ()
 
-    let hideFirstQuestCheckBox  = new CheckBox(Content=new TextBox(Text="HFQ",FontSize=12.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true))
+    let hideFirstQuestCheckBox  = new CheckBox(Content=new TextBox(Text="HFQ",FontSize=12.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true, Padding=Thickness(0.)))
     ToolTip.SetTip(hideFirstQuestCheckBox, "Hide First Quest\nIn a mixed quest overworld tracker, shade out the first-quest-only spots.\nUseful if you're unsure if randomizer flags are mixed quest or second quest.\nCan't be used if you've marked a first-quest-only spot as having something.")
-    let hideSecondQuestCheckBox = new CheckBox(Content=new TextBox(Text="HSQ",FontSize=12.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true))
+    let hideSecondQuestCheckBox = new CheckBox(Content=new TextBox(Text="HSQ",FontSize=12.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true, Padding=Thickness(0.)))
     ToolTip.SetTip(hideSecondQuestCheckBox, "Hide Second Quest\nIn a mixed quest overworld tracker, shade out the second-quest-only spots.\nUseful if you're unsure if randomizer flags are mixed quest or first quest.\nCan't be used if you've marked a second-quest-only spot as having something.")
 
     hideFirstQuestCheckBox.IsChecked <- System.Nullable.op_Implicit false
@@ -382,7 +382,7 @@ let makeAll(owMapNum) =
     canvasAdd(c, bombIcon, OFFSET+160., 30.)
 
     // shield versus book icon (for boomstick flags/seeds)
-    let toggleBookShieldCheckBox  = new CheckBox(Content=new TextBox(Text="S/B",FontSize=12.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true))
+    let toggleBookShieldCheckBox  = new CheckBox(Content=new TextBox(Text="S/B",FontSize=12.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true, Padding=Thickness(0.)))
     ToolTip.SetTip(toggleBookShieldCheckBox, "Shield item icon instead of book item icon")
     toggleBookShieldCheckBox.IsChecked <- System.Nullable.op_Implicit false
     toggleBookShieldCheckBox.Checked.Add(fun _ -> toggleBookMagicalShield())
@@ -761,34 +761,34 @@ let makeAll(owMapNum) =
     let legendCanvas = new Canvas()
     canvasAdd(c, legendCanvas, LEFT_OFFSET, THRU_MAIN_MAP_H)
 
-    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="The LEGEND\nof Z-Tracker")
+    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="The LEGEND\nof Z-Tracker", Padding=Thickness(0.))
     canvasAdd(c, tb, 0., THRU_MAIN_MAP_H)
 
     canvasAdd(legendCanvas, trimNumeralBmpToImage Graphics.uniqueMapIconBMPs.[0], 0., 0.)
     drawDungeonHighlight(legendCanvas,0.,0)
-    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Active\nDungeon")
+    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Active\nDungeon", Padding=Thickness(0.))
     canvasAdd(legendCanvas, tb, OMTW, 0.)
 
     canvasAdd(legendCanvas, trimNumeralBmpToImage Graphics.uniqueMapIconBMPs.[0], 2.5*OMTW, 0.)
     drawDungeonHighlight(legendCanvas,2.5,0)
     drawCompletedDungeonHighlight(legendCanvas,2.5,0)
-    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Completed\nDungeon")
+    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Completed\nDungeon", Padding=Thickness(0.))
     canvasAdd(legendCanvas, tb, 3.5*OMTW, 0.)
 
     canvasAdd(legendCanvas, trimNumeralBmpToImage Graphics.uniqueMapIconBMPs.[0], 5.*OMTW, 0.)
     drawDungeonHighlight(legendCanvas,5.,0)
     drawDungeonRecorderWarpHighlight(legendCanvas,5.,0)
-    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Recorder\nDestination")
+    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Recorder\nDestination", Padding=Thickness(0.))
     canvasAdd(legendCanvas, tb, 6.*OMTW, 0.)
 
     canvasAdd(legendCanvas, trimNumeralBmpToImage Graphics.uniqueMapIconBMPs.[9], 7.5*OMTW, 0.)
     drawWarpHighlight(legendCanvas,7.5,0)
-    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Any Road\n(Warp)")
+    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Any Road\n(Warp)", Padding=Thickness(0.))
     canvasAdd(legendCanvas, tb, 8.5*OMTW, 0.)
 
     let legendStartIcon = new Shapes.Ellipse(Width=float(11*3)-2., Height=float(11*3)-2., Stroke=Brushes.Lime, StrokeThickness=3.0)
     canvasAdd(legendCanvas, legendStartIcon, 10.*OMTW+8.5*OMTW/48., 0.)
-    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Start\nSpot")
+    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Start\nSpot", Padding=Thickness(0.))
     canvasAdd(legendCanvas, tb, 11.*OMTW, 0.)
 
     let THRU_MAP_AND_LEGEND_H = THRU_MAIN_MAP_H + float(11*3)
@@ -797,7 +797,7 @@ let makeAll(owMapNum) =
     let itemProgressCanvas = new Canvas(Width=16.*OMTW, Height=30.)
     itemProgressCanvas.IsHitTestVisible <- false  // do not let this layer see/absorb mouse interactions
     canvasAdd(c, itemProgressCanvas, 0., THRU_MAP_AND_LEGEND_H)
-    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Item Progress")
+    let tb = new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, IsReadOnly=true, BorderThickness=Thickness(0.), Text="Item Progress", Padding=Thickness(0.))
     canvasAdd(c, tb, 38., THRU_MAP_AND_LEGEND_H + 4.)
 
     // Version
@@ -1728,7 +1728,7 @@ let makeAll(owMapNum) =
             allOwMapZoneImages |> Array2D.iteri (fun x y image -> image.Opacity <- 0.0)
             owMapZoneBoundaries |> Seq.iter (fun x -> x.Opacity <- 0.0)
             zoneNames |> Seq.iter (fun (hz,textbox) -> textbox.Opacity <- 0.0)
-    let zone_checkbox = new CheckBox(Content=new TextBox(Text="Show zones",FontSize=14.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true))
+    let zone_checkbox = new CheckBox(Content=new TextBox(Text="Zones",FontSize=14.0,Background=Brushes.Black,Foreground=Brushes.Orange,BorderThickness=Thickness(0.0),IsReadOnly=true))
     zone_checkbox.IsChecked <- System.Nullable.op_Implicit false
     zone_checkbox.Checked.Add(fun _ -> changeZoneOpacity(TrackerModel.HintZone.UNKNOWN,true))
     zone_checkbox.Unchecked.Add(fun _ -> changeZoneOpacity(TrackerModel.HintZone.UNKNOWN,false))

--- a/Z1R_Tracker/Z1R_Avalonia/UI.fs
+++ b/Z1R_Tracker/Z1R_Avalonia/UI.fs
@@ -802,7 +802,7 @@ let makeAll(owMapNum) =
 
     // Version
     let vb = new Button(Content=new TextBox(FontSize=12., Foreground=Brushes.Orange, Background=Brushes.Black, BorderThickness=Thickness(0.), 
-                            Text=sprintf "v%s" OverworldData.VersionString, IsReadOnly=true, IsHitTestVisible=false),
+                            Text=sprintf "v%s" OverworldData.VersionString, IsReadOnly=true, IsHitTestVisible=false, Padding=Thickness(0.)),
                         BorderThickness=Thickness(1.), Margin=Thickness(0.), Padding=Thickness(0.))
     canvasAdd(c, vb, 0., THRU_MAP_AND_LEGEND_H + 4.)
     vb.Click.Add(fun _ ->

--- a/Z1R_Tracker/Z1R_Avalonia/UI.fs
+++ b/Z1R_Tracker/Z1R_Avalonia/UI.fs
@@ -1091,7 +1091,10 @@ let makeAll(owMapNum) =
     // timeline & options menu
     let moreOptionsLabel = new TextBox(Text="Options...", Foreground=Brushes.Orange, Background=Brushes.Black, FontSize=12., Margin=Thickness(0.), Padding=Thickness(0.), BorderThickness=Thickness(0.), IsReadOnly=true, IsHitTestVisible=false)
     let moreOptionsButton = new Button(MaxHeight=25., Content=moreOptionsLabel, BorderThickness=Thickness(1.), Margin=Thickness(0.), Padding=Thickness(0.))
-    let optionsCanvas = OptionsMenu.makeOptionsCanvas(c.Width, float TCH + 6., 25.)
+    let optionsCanvas = new Border(Child=OptionsMenu.makeOptionsCanvas(25.),
+                                   Background=SolidColorBrush(0xFF282828u), BorderBrush=Brushes.Gray, BorderThickness=Thickness(2.),
+                                   ZIndex=111, IsVisible=false)
+    moreOptionsButton.ZIndex <- optionsCanvas.ZIndex+1
 
     let theTimeline1 = new Timeline.Timeline(21., 4, 60, 5, c.Width-10., 1, "0h", "30m", "1h", 53.)
     let theTimeline2 = new Timeline.Timeline(21., 4, 60, 5, c.Width-10., 2, "0h", "1h", "2h", 53.)
@@ -1122,19 +1125,16 @@ let makeAll(owMapNum) =
     canvasAdd(c, optionsCanvas, 0., THRU_MAP_H)
     canvasAdd(c, moreOptionsButton, 0., THRU_MAP_H)
     moreOptionsButton.Click.Add(fun _ -> 
-        if optionsCanvas.Opacity = 0. then
-            optionsCanvas.Opacity <- 1.
-            optionsCanvas.IsHitTestVisible <- true
+        if not optionsCanvas.IsVisible then
+            optionsCanvas.IsVisible <- true
         else
-            optionsCanvas.Opacity <- 0.
-            optionsCanvas.IsHitTestVisible <- false
+            optionsCanvas.IsVisible <- false
+            TrackerModel.Options.writeSettings()
         )
     // auto-close logic
-    c.PointerMoved.Add(fun ea ->
-        let pos = ea.GetPosition(optionsCanvas)
-        if optionsCanvas.IsHitTestVisible && (pos.Y < 0. || pos.Y > optionsCanvas.Height) then
-            optionsCanvas.Opacity <- 0.
-            optionsCanvas.IsHitTestVisible <- false
+    optionsCanvas.PointerLeave.Add(fun ea ->
+        if optionsCanvas.IsVisible then
+            optionsCanvas.IsVisible <- false
             TrackerModel.Options.writeSettings()
         )
 


### PR DESCRIPTION
Hides extraneous borders and other minor visual cleanup.
Removes options menu outer canvas and width/height setting and hidden
default, caller is now responsible for adding a wrapping container if
needed.