### PR TITLE
Add support for a magic "next any-road" hotkey

### DIFF
--- a/Z1R_Tracker/Z1R_Tracker/TrackerModel.fs
+++ b/Z1R_Tracker/Z1R_Tracker/TrackerModel.fs
@@ -197,6 +197,9 @@ let allItemWithHeartShuffleChoiceDomain = ChoiceDomain("allItemsWithHeartShuffle
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
+[<Literal>]
+let OverworldAnyRoadNext = 36
+
 let overworldTiles(isFirstQuestOverworld) = [|
     // hotkey name       maxuses                                              popup display text
     "Level1"           , 1                                                  , "Dungeon"
@@ -239,6 +242,7 @@ let overworldTiles(isFirstQuestOverworld) = [|
     "TakeAny"          , 4                                                  , "Take Any One\nYou Want"
     "PotionShop"       , (if isFirstQuestOverworld then 7 else 9)           , "Potion Shop\n(20-60, 48-88 rupees)"
     "DarkX"            , 999                                                , "Don't Care"
+    "AnyRoadNext"      , 0                                                  , "Pseudo-tile for hotkeys"
     |]   // 1Q has 73 total spots, 2Q has 80
 let dummyOverworldTiles = overworldTiles(true)  // some bits need to read the hotkey names or array length, before the 1Q/2Q choice has been made by the user, this gives them that info
 

--- a/Z1R_Tracker/Z1R_WPF/OverworldMapTileCustomization.fs
+++ b/Z1R_Tracker/Z1R_WPF/OverworldMapTileCustomization.fs
@@ -355,6 +355,17 @@ let DoLeftClick(cm,msp:MapStateProxy,i,j,pos:Point,popupIsActive:ref<bool>) = as
 
 let DoSpecialHotKeyHandlingForOverworldTiles(i, j, originalState, hotKeyedState) =
     // rather than have many idempotent keys, turn some of them into useful actions
+
+    // black magic for "take any road"
+    let hotKeyedState =
+        match hotKeyedState with
+        | TrackerModel.OverworldAnyRoadNext ->
+            if   TrackerModel.mapSquareChoiceDomain.CanAddUse( 9) then 9
+            elif TrackerModel.mapSquareChoiceDomain.CanAddUse(10) then 10
+            elif TrackerModel.mapSquareChoiceDomain.CanAddUse(11) then 11
+            else 12
+        | _ -> hotKeyedState
+
     let orig = MapStateProxy(originalState)
     if orig.IsThreeItemShop then
         let item2 = TrackerModel.getOverworldMapExtraData(i,j,TrackerModel.MapSquareChoiceDomainHelper.SHOP) - 1   // 0-based


### PR DESCRIPTION
Adds a pseudo-tile (number 36) with the name AnyRoadNext.
By binding a hotkey to 'Overworld_AnyRoadNext', that hotkey will
automatically select the next available Any-Road tile.